### PR TITLE
Fix login bug and remove all obligatory arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 secrets.json
-steamcmd
+server


### PR DESCRIPTION
Fix login bug:
* when no "beta" param is specified, the -beta argument is still added to the steamcmd arguments which results in a login error

Remove all obligatory arguments
* ip: you had to specifiy it (now it uses the first network adapters ip by default)
* priority: you had to specifiy it (now it uses the highest priority by default)
* cores: you had to specify it (now it uses all by default)

Why is this important?
* Some steam server apps do not require the ip to be set (they can ignore the argument)
* you don't need to know the ip of the machine or need to change the config when you use it on a different machine / different ip
* you don't need to know the number of logical cores


Thank you very much for creating this tool @shamelesscookie!